### PR TITLE
feat/BACK 2178

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/core",
-  "version": "2.4.2",
+  "version": "2.4.3-fee-amount.0",
   "description": "Common library used between different paraswap packages",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/core",
-  "version": "2.4.3-fee-amount.3",
+  "version": "2.4.3",
   "description": "Common library used between different paraswap packages",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/core",
-  "version": "2.4.3-fee-amount.1",
+  "version": "2.4.3-fee-amount.2",
   "description": "Common library used between different paraswap packages",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/core",
-  "version": "2.4.3-fee-amount.2",
+  "version": "2.4.3-fee-amount.3",
   "description": "Common library used between different paraswap packages",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/core",
-  "version": "2.4.3-fee-amount.0",
+  "version": "2.4.3-fee-amount.1",
   "description": "Common library used between different paraswap packages",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export type OptimalRate = {
   network: number;
   srcToken: Address;
   srcDecimals: number;
-  srcAmountBeforeFee?: NumberAsString; // used for BUY with partner fee
+  srcAmountAfterFee?: NumberAsString; // used for BUY with partner fee
   srcAmount: NumberAsString;
   srcUSD: NumberAsString | null;
   destToken: Address;

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,12 +43,13 @@ export type OptimalRate = {
   network: number;
   srcToken: Address;
   srcDecimals: number;
+  srcAmountBeforeFee?: NumberAsString; // used for BUY with partner fee
   srcAmount: NumberAsString;
   srcUSD: NumberAsString | null;
   destToken: Address;
   destDecimals: number;
   destAmount: NumberAsString;
-  destAmountAfterFee?: NumberAsString;
+  destAmountAfterFee?: NumberAsString; // used for SELL with partner fee
   destUSD: NumberAsString | null;
   bestRoute: OptimalRoute[];
   gasCostUSD: NumberAsString;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export type OptimalRate = {
   destToken: Address;
   destDecimals: number;
   destAmount: NumberAsString;
+  destAmountAfterFee?: NumberAsString;
   destUSD: NumberAsString | null;
   bestRoute: OptimalRoute[];
   gasCostUSD: NumberAsString;


### PR DESCRIPTION
- **feat: add new `destAmountAfterFee` field on price route**
- **2.4.3-fee-amount.0**
- **2.4.3-fee-amount.1**
- **feat: add `srcAmountBeforeFee` field**
- **2.4.3-fee-amount.2**
- **feat: rename `srcAmountBeforeFee` to `srcAmountAfterFee`**
- **2.4.3-fee-amount.3**
- **2.4.3**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive TypeScript type updates (optional fields) plus a version bump, with no runtime logic modifications.
> 
> **Overview**
> Adds optional `srcAmountAfterFee` and `destAmountAfterFee` to `OptimalRate` to expose fee-adjusted amounts for partner-fee scenarios (BUY and SELL respectively).
> 
> Bumps the package version from `2.4.2` to `2.4.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8ec57a9ce4ccfee56b8a8c09d164993281280f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->