### PR TITLE
feat(DEXLIB-179): add fallback field to OptimalSwapExchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/core",
-  "version": "2.4.3",
+  "version": "2.4.4-fallback.0",
   "description": "Common library used between different paraswap packages",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/core",
-  "version": "2.4.4-fallback.0",
+  "version": "2.4.4",
   "description": "Common library used between different paraswap packages",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,10 @@ export type OptimalSwapExchange<T> = {
   data?: T;
   poolAddresses?: Array<Address>;
   poolIdentifiers?: Array<string>;
+  // Revertable fallback alternative for the same hop: if the primary swap
+  // reverts on-chain, the executor runs this exchange instead from the same
+  // input (encoded by dex-lib as a revertable group on Executor01/02).
+  fallback?: OptimalSwapExchange<T>;
 };
 
 export type OptionalRate = {


### PR DESCRIPTION
## Summary

Adds an optional `fallback` field to `OptimalSwapExchange` — the revertable fallback alternative for the same hop. When the primary swap reverts on-chain, the executor runs the fallback exchange from the same input (encoded by dex-lib as a revertable group on Executor01/02).

Formalizes the local type extensions currently used in dex-lib and the api (Option A of the swap-fallback design). Backwards compatible: the field is optional and the priceRoute HMAC covers it automatically.

Published as `2.4.4-fallback.0` under the `fallback` dist-tag.

Part of DEXLIB-179; pairs with:
- VeloraDEX/paraswap-augustus#116 (contracts)
- VeloraDEX/paraswap-dex-lib#1202 (encoding)
- VeloraDEX/paraswap-api#1697 (pricing)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only, optional field in a shared types package with no runtime logic changes in this repo.
> 
> **Overview**
> Adds an optional, recursive **`fallback`** field on **`OptimalSwapExchange`** so a hop can carry a revertable backup exchange: if the primary swap reverts on-chain, the executor is expected to run the fallback from the same input (as encoded by dex-lib revertable groups on Executor01/02). This formalizes swap-fallback typing that was previously extended locally in dex-lib and the API.
> 
> Bumps **`@paraswap/core`** from **2.4.3** to **2.4.4**. The field is optional, so existing consumers stay compatible; downstream packages can start populating **`fallback`** on price routes without breaking older types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d115015f190367a3199fcb0380cd5092e8b4845b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->