### PR TITLE
feat(DEXLIB-196): add targetExchange to OptimalSwapExchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/core",
-  "version": "2.4.5-0",
+  "version": "2.4.5",
   "description": "Common library used between different paraswap packages",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/core",
-  "version": "2.4.4",
+  "version": "2.4.5-0",
   "description": "Common library used between different paraswap packages",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,9 @@ export type OptimalSwapExchange<T> = {
   data?: T;
   poolAddresses?: Array<Address>;
   poolIdentifiers?: Array<string>;
+  // The contract the hop's swap call targets (router/settlement) — lets
+  // analytics attribute on-chain reverts to a venue.
+  targetExchange?: Address;
   // Revertable fallback alternative for the same hop: if the primary swap
   // reverts on-chain, the executor runs this exchange instead from the same
   // input (encoded by dex-lib as a revertable group on Executor01/02).


### PR DESCRIPTION
Optional `targetExchange` on `OptimalSwapExchange` — the contract the hop's swap call targets (router/settlement), populated at pricing (VeloraDEX/paraswap-dex-lib#1212) and threaded onto route hops by the api (VeloraDEX/paraswap-api#1705) so on-chain reverts can be attributed to a venue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional field and a patch version bump with no runtime logic changes in this repo.
> 
> **Overview**
> Extends **`OptimalSwapExchange`** with an optional **`targetExchange`** address: the router/settlement contract the hop’s swap call targets, so downstream analytics can attribute on-chain reverts to a venue.
> 
> Bumps **`@paraswap/core`** from **2.4.4** to **2.4.5**. Population and threading onto route hops are handled in separate dex-lib and API PRs; this change is the shared type contract only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530fee0a0f9581e91588658d25eaa4792cec17b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->